### PR TITLE
Fix/update-build-script

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
             cp -r .bluetooth/* build/mnt/mmc/MUOS/application/Bluetooth
             cp .bluetooth/bin/bluetooth.sh build/run/muos/storage/init
             cp package/mux_launch.sh build/mnt/mmc/MUOS/application/Bluetooth
-            cp package/update.sh /opt
+            cp package/update.sh build/opt
             cp  .bluetooth/Assets/Icon/ic_bluetooth.png build/opt/muos/default/MUOS/theme/active/glyph/muxapp/bluetooth.png
         - name: Package muxupd
           run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,31 +13,28 @@ jobs:
     steps:
         - name: Check out repo
           uses: actions/checkout@v2
-        - name:  Create packages directory
-          run: mkdir -p packages/muxzip
-        - name: Create muxzip structure
+        - name:  Create muxupd directory
+          run: mkdir -p build
+        - name: Create muxupd structure
           run: |
-            mkdir -p packages/muxzip/mnt/mmc/MUOS/application/Bluetooth
-            mkdir -p packages/muxzip/opt/muos/default/MUOS/theme/active/glyph/muxapp
-        - name: Move files to muxzip tree
+            mkdir -p build/mnt/mmc/MUOS/application/Bluetooth
+            mkdir -p build/opt/muos/default/MUOS/theme/active/glyph/muxapp
+            mkdir -p build/run/muos/storage/init
+        - name: Move files to muxupd tree
           run: |
-            cp -r .bluetooth/* packages/muxzip/mnt/mmc/MUOS/application/Bluetooth
-            cp package/mux_launch.sh packages/muxzip/mnt/mmc/MUOS/application/Bluetooth
-            cp  .bluetooth/Assets/Icon/ic_bluetooth.png packages/muxzip/opt/muos/default/MUOS/theme/active/glyph/muxapp/bluetooth.png
-        - name: Package muxzip
+            cp -r .bluetooth/* build/mnt/mmc/MUOS/application/Bluetooth
+            cp .bluetooth/bin/bluetooth.sh build/run/muos/storage/init
+            cp package/mux_launch.sh build/mnt/mmc/MUOS/application/Bluetooth
+            cp package/update.sh /opt
+            cp  .bluetooth/Assets/Icon/ic_bluetooth.png build/opt/muos/default/MUOS/theme/active/glyph/muxapp/bluetooth.png
+        - name: Package muxupd
           run: |
-            cd packages/muxzip
+            cd build
             zip -r Bluetooth-Install-Full-PIXIE.zip .
-            mv Bluetooth-Install-Full-PIXIE.zip ../Bluetooth-Install-Full-PIXIE.muxzip
-        - name: Create muxupd file
-          run: |
-            cd .bluetooth
-            zip -r Bluetooth-Install-Update-PIXIE.zip . ../package/mux_launch.sh
-            mv Bluetooth-Install-Update-PIXIE.zip ../packages/Bluetooth-Install-Update-PIXIE.muxupd
+            mv Bluetooth-Install-Full-PIXIE.zip Bluetooth-Install-Full-PIXIE.muxupd
         - name: Upload artifact
           uses: actions/upload-artifact@v4
           with:
-            name: MUOS Bluetooth Pixie Installers
+            name: MUOS Bluetooth Pixie Installer
             path: |
-              packages/Bluetooth-Install-Full-PIXIE.muxzip
-              packages/Bluetooth-Install-Update-PIXIE.muxupd
+              build/Bluetooth-Install-Full-PIXIE.muxupd

--- a/package/update.sh
+++ b/package/update.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+. /opt/muos/script/var/func.sh
+
+chmod +x /usr/bin/expect
+
+SET_VAR "global" "settings/advanced/user_init" "1"
+/opt/muos/script/system/halt.sh reboot
+
+sleep infinity


### PR DESCRIPTION
- Add `update.sh` from release to repo
- Replace `.muxzip` build from GitHub Actions workflow with updated `.muxupd` build
- Remove old ~~incorrect~~ `.muxupd` build from actions