### PR TITLE
added autopair functionality

### DIFF
--- a/.bluetooth/bluetooth.lua
+++ b/.bluetooth/bluetooth.lua
@@ -166,6 +166,33 @@ function Bluetooth.Pair(deviceMAC)
     os.execute("bluetoothctl pair " .. deviceMAC)
 end
 
+-- AUTOPAIR FUNCTIONALITY
+-- returns: true if the device has been configured for startup, false if removed
+function Bluetooth.ToggleAutopair(deviceMAC)
+	local file = io.open(Config.BLUETOOTH_STARTUP_PATH)
+	if file then
+		for line in file:lines() do
+			if string.find(line,deviceMAC) then
+				file:close()
+				Bluetooth.AutopairRemove(deviceMAC)
+				return false
+			end
+		end
+	end
+	Bluetooth.Autopair(deviceMAC)
+	return true
+end
+
+function Bluetooth.Autopair(deviceMAC)
+	os.execute("echo \"bluetoothctl connect " .. deviceMAC .. "\" >> " .. Config.BLUETOOTH_STARTUP_PATH)
+end
+
+function Bluetooth.AutopairRemove(deviceMAC)
+	local rmstr = "bluetoothctl connect " .. deviceMAC
+	os.execute("grep -v \"" .. deviceMAC .. "\" " .. Config.BLUETOOTH_STARTUP_PATH .. " > tmpfile && mv tmpfile " .. Config.BLUETOOTH_STARTUP_PATH)
+	local file = io.open
+end
+
 function Bluetooth.GetBatteryPercent()
     for _,device in ipairs(connectedDevices) do
         if device.type == Bluetooth.ConnectedType.CONNECTED then

--- a/.bluetooth/config.lua
+++ b/.bluetooth/config.lua
@@ -14,6 +14,7 @@ Config.AUDIO_SINK_NUMBER = "data/sinknumber.txt"
 Config.AUDIO_SINKS = "data/sinks.txt"
 
 Config.BLUETOOTH_EXPECT_PATH = "bin/bluetooth_expect_script.exp"
+Config.BLUETOOTH_STARTUP_PATH = "/mnt/mmc/MUOS/init/bluetooth.sh"
 
 -- Grid
 Config.GRID_PAGE_ITEM = 7

--- a/.bluetooth/main.lua
+++ b/.bluetooth/main.lua
@@ -299,6 +299,22 @@ function TurnOffBluetooth()
     end
 end
 
+function AutopairDevice()
+	if isAvailableDevicesSelected then
+		return
+	end
+	
+	local pos = (currConnectedDevicePage - 1) * Config.GRID_PAGE_ITEM + idxConnectedDevice
+        local MAC = connectedDevices[pos].ip
+	local result = Bluetooth.ToggleAutopair(MAC)
+	-- result: autopair added
+	if result == true then
+		msgLog = "Autopair set!"
+	else
+		msgLog = "Autopair removed!"
+	end
+end
+
 function ConnectDevice()
     if (    isAvailableDevicesSelected and table.getn(availableDevices) < 1)
         or (not isAvailableDevicesSelected
@@ -553,6 +569,8 @@ function ConnectedDevicesUI()
     love.graphics.draw(ic_L1, xPos + 130, yPos + height - 22)
     love.graphics.print("Audio", xPos + 130 + 30, yPos + height - 20)
     
+    -- Autopair button
+    love.graphics.print("R1-Autopair", xPos + 130 + 80, yPos + height - 20)
 end
 
 function LoadConnectedDevices()
@@ -866,6 +884,11 @@ function love.gamepadpressed(joystick, button)
             if key == "x" then
                 DisconnectDevice()
                 return
+            end
+            
+            if key == "r1" then
+            	AutopairDevice()
+            	return
             end
 
             if key == "up" then


### PR DESCRIPTION
todo: add an R1 icon and verify the correct bluetooth.sh path in config.lua

Potential future functionality might be to add an autopair indicator in the connected devices list for a bit of ergonomics. I'm happy to discuss adding this feature or anything else you feel it needs before merging. 