### PR TITLE
Fix buttons on TrimUI Smart Pro

### DIFF
--- a/.bluetooth/main_trimui.lua
+++ b/.bluetooth/main_trimui.lua
@@ -724,8 +724,8 @@ function love.draw()
     else
         love.graphics.draw(ic_bluetooth_big, 640/2 - 60, 480/2 - 100)
         love.graphics.print("Press", 220, 253)
-        love.graphics.draw(ic_R1, 220 + 40, 255)
-        love.graphics.print("to turn on Bluetooth", 260 + 27, 253)
+        love.graphics.draw(ic_select, 220 + 40, 255)
+        love.graphics.print("to turn on Bluetooth", 260 + 40, 253)
     end
 
     BottomButtonUI()
@@ -765,14 +765,6 @@ function love.update(dt)
     end
 end
 
-function love.keypressed(key)
-    if key == "l" then
-        key = "l1"
-    end
-
-    OnKeyPress(key)
-end
-
 function love.gamepadpressed(joystick, button)
     local key = ""
     if button == "dpleft" then
@@ -787,33 +779,30 @@ function love.gamepadpressed(joystick, button)
     if button == "dpdown" then
         key = "down"
     end
-    if button == "rightshoulder" then
+    if button == "a" then
         key = "a"
     end
-    if button == "leftshoulder" then
+    if button == "b" then
         key = "b"
     end
-    if button == "start" then
+    if button == "x" then
         key = "x"
     end
-    if button == "back" then
+    if button == "y" then
         key = "y"
     end
-    -- if button == "back" then
-        -- key = "select"
-    -- end
-    -- if button == "start" then
-        -- key = "start"
-    -- end
     if button == "guide" then
-        key = "l1"
+        key = "select"
     end
-    if button == "leftstick" then
+    if button == "start" then
         key = "start"
     end
-    -- if button == "guide" then
-        -- key = "guide"
-    -- end
+    if button == "leftshoulder" then
+        key = "l1"
+    end
+    if button == "rightshoulder" then
+        key = "r1"
+    end
 
     OnKeyPress(key)
  end
@@ -967,7 +956,7 @@ function love.gamepadpressed(joystick, button)
         end
     end
     else
-        if key == "start" then
+        if key == "select" then
             TurnOnBluetooth()
             return
         end

--- a/package/mux_launch_trimui.sh
+++ b/package/mux_launch_trimui.sh
@@ -5,21 +5,27 @@
 
 . /opt/muos/script/var/func.sh
 
-echo app >/tmp/ACT_GO
+echo app >/tmp/act_go
+
+GOV_GO="/tmp/gov_go"
+[ -e "$GOV_GO" ] && cat "$GOV_GO" >"$(GET_VAR "device" "cpu/governor")"
+
+SETUP_SDL_ENVIRONMENT
 
 LOVEDIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/application/Bluetooth"
-GPTOKEYB="$(GET_VAR "device" "storage/rom/mount")/MUOS/emulator/gptokeyb/gptokeyb2.armhf"
+
+PM_DIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/PortMaster"
+GPTOKEYB="${PM_DIR}/gptokeyb2"
 BINDIR="$LOVEDIR/bin"
 
-SDL_GAMECONTROLLERCONFIG_FILE="/usr/lib/gamecontrollerdb.txt"
 LD_LIBRARY_PATH="$BINDIR/libs.aarch64:$LD_LIBRARY_PATH"
-export SDL_GAMECONTROLLERCONFIG_FILE LD_LIBRARY_PATH
+export LD_LIBRARY_PATH
 
 # Launcher
 cd "$LOVEDIR" || exit
-SET_VAR "SYSTEM" "FOREGROUND_PROCESS" "love"
+SET_VAR "system" "foreground_process" "love"
 
 # Run Application
-"love" &
+"${GPTOKEYB}" "$BINDIR/love" &
 "$BINDIR/love" .
 kill -9 "$(pidof gptokeyb2)" 2>/dev/null


### PR DESCRIPTION
The application didn't receive any button inputs on the TrimUI Smart Pro. I checked what can be the issue and noticed that other apps like Moonlight use gptokeyb2. I added it to the launcher script and also fixed the buttons in main where it was different.