### PR TITLE
Keep paired devices after reboot

### DIFF
--- a/.bluetooth/bin/bluetooth_trimui.sh
+++ b/.bluetooth/bin/bluetooth_trimui.sh
@@ -26,6 +26,17 @@ start_hci()
 	}
 }
 
+setup_persistent_storage()
+{
+    # Clean up old symlink(s)
+    find /var/lib/bluetooth -name ??:??:??:??:??:?? -type l -exec unlink {} \;
+    bdaddr=`hciconfig hci0 | awk '/BD Address/ {print $3}'`
+    # Make sure the persistent storage directory exists
+    mkdir -p /var/lib/bluetooth/persistent_storage
+    # Create link with current random address and then bluetoothd can start using it
+    ln -sf persistent_storage "/var/lib/bluetooth/$bdaddr"
+}
+
 start_bluetooth()
 {
     /usr/libexec/bluetooth/bluetoothd -n -d > /mnt/mmc/MUOS/log/bluetoothd.log 2>&1 &
@@ -49,4 +60,5 @@ start_bluetooth()
 
 start_hci_attach
 start_hci
+setup_persistent_storage
 start_bluetooth


### PR DESCRIPTION
TrimUI devices tend to forget already paired Bluetooth devices after a reboot. The paired devices always disappear because the bluetooth interface gets a new random HW address every time the device boots up. Bluetoothd stores information about paired devices in /var/lib/bluetooth/<bdaddr>/, which is a new directory each time the system starts. This commit replaces the /var/lib/bluetooth/<bdaddr>/ directory with a symlink thats points to a folder where the information of the connected devices are stored permanently.